### PR TITLE
added support for yum cookbook v3

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -9,7 +9,16 @@ pkgs = value_for_platform(
 )
 
 if(platform?(*%w(redhat centos fedora scientific)))
-  include_recipe 'yum::epel'
+  begin
+    include_recipe 'yum::epel'
+  rescue
+    yum_repository 'epel' do
+      description 'Extra Packages for Enterprise Linux'
+      mirrorlist 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
+      gpgkey 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+      action :create
+    end
+  end
   if(node[:nginx_simplecgi][:init_type].to_sym == :upstart)
     node.set[:nginx_simplecgi][:init_type] = 'init'
   end


### PR DESCRIPTION
When using Yum cookbook v3, chef throws exception because yum::epel no longer exists. I'm catching exception and adding epel via V3 LWRP.
